### PR TITLE
Allow mmark checker in zettel-mode

### DIFF
--- a/flycheck-mmark.el
+++ b/flycheck-mmark.el
@@ -66,7 +66,7 @@ See: https://github.com/mmark-md/mmark-cli"
   :command        ("mmark" "--json" "--ofile" null-device)
   :standard-input t
   :error-parser   flycheck-mmark-parse-errors
-  :modes          markdown-mode)
+  :modes          (zettel-mode markdown-mode))
 
 ;;;###autoload
 (defun flycheck-mmark-setup ()


### PR DESCRIPTION
`zettel-mode` is an Emacs major mode derived from [`markdown-mode`](https://jblevins.org/projects/markdown-mode/)

https://github.com/felko/zettel-mode

---

Or am I missing something, and that there is a better way to do this?